### PR TITLE
Use SwitchEntity instead of deprecated SwitchDevice

### DIFF
--- a/switch.py
+++ b/switch.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 from datetime import timedelta
 
-from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.components.switch import SwitchEntity, PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_USERNAME, CONF_PASSWORD,
     CONF_SSL, CONF_RESOURCES, CONF_SCAN_INTERVAL
@@ -89,7 +89,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     add_entities_callback(switches)
 
 
-class NetgearEnhancedSwitch(SwitchDevice):
+class NetgearEnhancedSwitch(SwitchEntity):
     """Representation of a netgear enhanced switch."""
 
     def __init__(self, args, kind, scan_interval):


### PR DESCRIPTION
SwitchDevice was renamed to SwitchEntity in home assistant core. It doesn't look like there were any other changes in the class definition.
This change updates the integration to use SwitchEntity instead of SwitchDevice. Verified that the warning in the log is gone (https://github.com/roblandry/netgear-enhanced-integration/issues/2) and tested that switches still work - tested with 2g_guest_wifi and 5g_guest_wifi switches.