### PR TITLE
Add "version" to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "Netgear Enhanced",
   "documentation": "https://gitlab.landry.me/Home-Assistant/custom_components/netgear-enhanced-sensor",
   "dependencies": [],
+  "version": "v0.0.1",
   "codeowners": ["@bigrob8181"],
   "requirements": ["pynetgear-enhanced==0.2.2"]
 }


### PR DESCRIPTION
Home assistant is logging this warning:

> No 'version' key in the manifest file for custom integration 'netgear_enhanced'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'netgear_enhanced'

I think this will fix that.